### PR TITLE
feat(web!): add forgot password and reset password

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,12 +472,14 @@ dependencies = [
  "axum",
  "axum-extra",
  "axum-macros",
+ "chrono",
  "dotenv",
  "dotenv_codegen",
  "easy_password",
  "futures",
  "headers",
  "http",
+ "lettre",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -488,6 +490,7 @@ dependencies = [
  "tokio",
  "tower",
  "tower-http",
+ "uuid",
 ]
 
 [[package]]
@@ -941,6 +944,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "email-encoding"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbfb21b9878cf7a348dcb8559109aabc0ec40d69924bd706fa5149846c4fef75"
+dependencies = [
+ "base64",
+ "memchr",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2153bd83ebc09db15bcbdc3e2194d901804952e3dc96967e1cd3b0c5c32d112"
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1030,6 +1049,15 @@ dependencies = [
  "quote",
  "syn 1.0.109",
  "synstructure",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -1612,6 +1640,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi",
+]
+
+[[package]]
 name = "http"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1705,6 +1744,16 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
@@ -1785,6 +1834,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1873,6 +1931,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
+name = "lettre"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76bd09637ae3ec7bd605b8e135e757980b3968430ff2b1a4a94fb7769e50166d"
+dependencies = [
+ "base64",
+ "email-encoding",
+ "email_address",
+ "fastrand 1.9.0",
+ "futures-util",
+ "hostname",
+ "httpdate",
+ "idna 0.3.0",
+ "mime",
+ "native-tls",
+ "nom",
+ "once_cell",
+ "quoted_printable",
+ "socket2 0.4.9",
+ "tokio",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1925,6 +2006,12 @@ checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchit"
@@ -2039,6 +2126,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
  "getrandom 0.2.10",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -2211,6 +2316,50 @@ name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "openssl"
+version = "0.10.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
+dependencies = [
+ "bitflags 2.4.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "overload"
@@ -2497,6 +2646,12 @@ checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "quoted_printable"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3866219251662ec3b26fc217e3e05bf9c4f84325234dfb96bf0bf840889e49"
 
 [[package]]
 name = "rand"
@@ -2820,10 +2975,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.3",
+ "core-foundation-sys 0.8.4",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+dependencies = [
+ "core-foundation-sys 0.8.4",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -3441,7 +3628,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
- "fastrand",
+ "fastrand 2.0.1",
  "redox_syscall",
  "rustix",
  "windows-sys",
@@ -3895,7 +4082,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.4.0",
  "percent-encoding",
 ]
 
@@ -3912,6 +4099,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 dependencies = [
  "getrandom 0.2.10",
+ "rand 0.8.5",
+ "uuid-macro-internal",
+]
+
+[[package]]
+name = "uuid-macro-internal"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7e1ba1f333bd65ce3c9f27de592fcbc256dafe3af2717f56d7c87761fbaccf4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
 ]
 
 [[package]]

--- a/carnival-matchserver/src/connection.rs
+++ b/carnival-matchserver/src/connection.rs
@@ -22,7 +22,7 @@ pub fn connect(ipc: mpsc::Sender<String>) {
                 // If the message received back from the server does not return "match"
                 if resp_str != "match" {
                     // Check again in 5 seconds.
-                    socket.send(Message::Text("ack".to_string()));
+                    let _ = socket.send(Message::Text("ack".to_string()));
                     thread::sleep(Duration::from_secs(5));
                     continue;
                 }
@@ -30,7 +30,7 @@ pub fn connect(ipc: mpsc::Sender<String>) {
                 // If it does, listen for another packet containing the match data.
                 if let Ok(match_resp) = socket.read() {
                     // Tell the webserver that we have the data 
-                    socket.send(Message::Text("match ack".to_string()));
+                    let _ = socket.send(Message::Text("match ack".to_string()));
                     match ipc.send(match_resp.to_string()) {
                         Ok(_) => {},
                         Err(e) => eprintln!("{e}")

--- a/carnival-matchserver/src/main.rs
+++ b/carnival-matchserver/src/main.rs
@@ -3,7 +3,6 @@ use std::{sync::mpsc, thread};
 use crate::{
     commons::types::ResolvedOverwatchMatch,
     config::Config,
-    overwatch::dyn_actions::DynamicActionChain,
 };
 use overwatch::state_handler::StateHandler;
 use tracing_subscriber::filter::LevelFilter;

--- a/carnival-matchserver/src/overwatch/dyn_actions.rs
+++ b/carnival-matchserver/src/overwatch/dyn_actions.rs
@@ -39,7 +39,7 @@ impl DynamicActionChain {
         if team == 2 {
             ret.get_mut(2).unwrap().y = 906;
         }
-        Self { 0: ret }
+        Self(ret)
     }
 
     pub fn invoke(&self) {

--- a/carnival-matchserver/src/overwatch/state_handler.rs
+++ b/carnival-matchserver/src/overwatch/state_handler.rs
@@ -17,6 +17,7 @@ impl StateHandler {
         self
     }
 
+    #[allow(dead_code)]
     fn to_toml(&self) -> Option<String> {
         if let Ok(json) = toml::to_string(self) {
             Some(json)
@@ -25,6 +26,7 @@ impl StateHandler {
         }
     }
 
+    #[allow(dead_code)]
     pub fn dump(&self) {
         if let Some(json_str) = self.to_toml() {
             if File::create("state_handler.toml").is_err() {

--- a/carnival-web/Cargo.toml
+++ b/carnival-web/Cargo.toml
@@ -15,12 +15,14 @@ async-channel = "1.9.0"
 axum = { version = "0.6.2", features = ["headers", "ws"] }
 axum-extra = { version = "0.8.0" }
 axum-macros = "0.3.8"
+chrono = "0.4.31"
 dotenv = "0.15.0"
 dotenv_codegen = "0.15.0"
 easy_password = "0.1.4"
 futures = "0.3.28"
 headers = "0.3.9"
 http = "0.2.9"
+lettre = "0.10"
 rand = { version = "0.8.5", features = ["std_rng"] }
 serde = "1.0.188"
 serde_json = "1.0.107"
@@ -31,3 +33,11 @@ static_str_ops = "0.1.2"
 tokio = { version = "1.32.0", features = ["full"] }
 tower = { version = "0.4.13", features = ["full"] }
 tower-http = { version = "0.4.4", features = ["full"] }
+
+[dependencies.uuid]
+version = "1.4.1"
+features = [
+    "v4",                # Lets you generate random UUIDs
+    "fast-rng",          # Use a faster (but still sufficiently random) RNG
+    "macro-diagnostics", # Enable better diagnostics for compile-time UUIDs
+]

--- a/carnival-web/sql/insert_user.sql
+++ b/carnival-web/sql/insert_user.sql
@@ -1,4 +1,4 @@
 INSERT INTO
-    users (username, password, battletag, role)
+    users (username, password, battletag, email, role)
 VALUES
-    (?, ?, ?, ?)
+    (?, ?, ?, ?, ?)

--- a/carnival-web/src/api/endpoints.rs
+++ b/carnival-web/src/api/endpoints.rs
@@ -1,25 +1,31 @@
-use std::{fs, net::SocketAddr};
+use std::fs;
 
 use crate::db::services::queue::pop_queue;
-use crate::db::services::session_token as session;
+use crate::db::services::{session_token as session, password_reset_token};
 use crate::{
     api::payloads::{LoginInput, RegisterInput},
     db::services::{queue, user},
     rendering::components::build_queue_comp,
     CarnyState, HMAC_KEY,
 };
+use axum::response::IntoResponse;
 use axum::{
     body::{Bytes, Full},
-    extract::{ConnectInfo, State},
+    extract::State,
     response::Response,
     Json, TypedHeader,
 };
+use chrono::{Utc, Duration};
 use easy_password::bcrypt::verify_password;
 use headers::Cookie;
 use http::{HeaderValue, StatusCode, HeaderMap};
+use lettre::{Message, SmtpTransport, Transport};
+use lettre::message::header::ContentType;
+use lettre::transport::smtp::authentication::Credentials;
 use static_str_ops::static_format;
+use uuid::Uuid;
 
-use super::payloads::{JoinQueueInput, LeaveQueueInput, UpdateSettingsInput};
+use super::payloads::{JoinQueueInput, LeaveQueueInput, UpdateSettingsInput, ForgotPasswordInput, ResetPasswordInput};
 
 async fn validate_session_cookie(
     user_id: i32,
@@ -36,11 +42,9 @@ pub async fn register(
     State(state): State<CarnyState>,
     Json(post_data): Json<RegisterInput>,
 ) -> (StatusCode, String) {
-    // NOTE(aalhendi): is this needed?
-    // NOTE(Carter): It's for clarity - putting 40 bytes on the stack
-    // doesn't matter.
     let username: &str = &post_data.username;
     let battletag: &str = &post_data.battletag;
+    let email: &str = &post_data.email;
     let role: &str = &post_data.role;
     let password: &str = &post_data.password;
     let password_conf: &str = &post_data.password_conf;
@@ -73,7 +77,15 @@ pub async fn register(
         );
     }
 
-    match user::create_user(username, password, battletag, role, &state.pool).await {
+    
+    if user::does_email_exist(email, &state.pool).await {
+        return (
+            StatusCode::BAD_REQUEST,
+            "Email already exists".to_string(),
+        );
+    }
+
+    match user::create_user(username, password, battletag, email, role, &state.pool).await {
         Ok(_) => {
             let redirect_js = fs::read_to_string("static/js/redirect_register.js")
                 .unwrap_or("User created. Error redirecting.".to_string());
@@ -185,6 +197,94 @@ pub async fn login(
     *r.status_mut() = StatusCode::BAD_REQUEST;
     *r.body_mut() = Full::from("Incorrect username or password");
     r
+}
+
+pub async fn forgot_password(
+    State(state): State<CarnyState>,
+    Json(post_data): Json<ForgotPasswordInput>,
+) -> impl IntoResponse {
+    // TODO(aalhendi): Validate email. Garde crate (https://github.com/jprochazk/garde) <- plug for the homie
+
+    let maybe_user = user::user_by_email(&post_data.email, &state.pool).await;
+    let user_id = match maybe_user {
+        Ok(u) => u.id,
+        Err(_) => todo!("Handle error silently, maybe return to user 'we sent a reset email if it exists in records'"),
+    };
+
+    let token = Uuid::new_v4().to_string();
+
+    let expires_at = (Utc::now() + Duration::hours(2)).timestamp();
+    // TODO(aalhendi): handle err maybe? HTTP 500
+    password_reset_token::store_token(user_id, &token, expires_at, &state.pool).await;
+
+    send_email(&post_data.email, &token).await; 
+    (StatusCode::OK, "Email will be sent if it exists in records :)")
+}
+
+pub async fn reset_password(
+    State(state): State<CarnyState>,
+    Json(post_data): Json<ResetPasswordInput>,
+) -> impl IntoResponse {
+    let token = &post_data.token;
+    let new_password = &post_data.new_password;
+
+    match password_reset_token::validate_token(token, &state.pool).await {
+        Ok(Some(user_id)) => {
+            match password_reset_token::update_password(user_id, new_password, &state.pool).await {
+                Ok(_) => {
+                    password_reset_token::delete_token(token, &state.pool)
+                        .await
+                        .expect("Failed to delete token");
+                    return (StatusCode::OK, "Password updated".to_string());
+                }
+                Err(_) => {
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "Failed to update password".to_string(),
+                    )
+                }
+            }
+        }
+        Ok(None) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                "Invalid or expired token".to_string(),
+            )
+        }
+        Err(_) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "An error occurred".to_string(),
+            )
+        }
+    }
+}
+
+// TODO(aalhendi): actually implement. this is literally the example on github modified...
+// lettre (https://github.com/lettre/lettre)
+async fn send_email(recipient_email: &str, token: &str) {
+    let email = Message::builder()
+        .from("no-reply@yourdomain.com".parse().unwrap())
+        .from(recipient_email.parse().unwrap())
+        .subject("Carnival Password Reset")
+        .header(ContentType::TEXT_PLAIN)
+        .body(format!("Here is your password reset token: {}", token))
+        .unwrap();
+
+
+    let creds = Credentials::new("smtp_username".to_string(), "smtp_password".to_string());
+
+    // Open a remote connection to gmail
+    let mailer = SmtpTransport::relay("smtp.gmail.com")
+        .unwrap()
+        .credentials(creds)
+        .build();
+
+    // Send the email
+    match mailer.send(&email) {
+        Ok(_) => println!("Email sent successfully!"),
+        Err(e) => panic!("Could not send email: {e:?}"),
+    }
 }
 
 pub async fn join_queue(

--- a/carnival-web/src/api/payloads.rs
+++ b/carnival-web/src/api/payloads.rs
@@ -6,13 +6,26 @@ pub struct RegisterInput {
     pub role: String,
     pub password: String,
     pub password_conf: String,
-    pub battletag: String
+    pub battletag: String,
+    pub email: String
 }
 
 #[derive(Deserialize)]
 pub struct LoginInput {
     pub username: String,
     pub password: String
+}
+
+#[derive(Deserialize)]
+pub struct ForgotPasswordInput {
+    pub email: String,
+}
+
+
+#[derive(Deserialize)]
+pub struct ResetPasswordInput {
+    pub token: String,
+    pub new_password: String,
 }
 
 // See LeaveQueueInput comment.

--- a/carnival-web/src/db/models.rs
+++ b/carnival-web/src/db/models.rs
@@ -23,6 +23,16 @@ pub struct User {
     pub wins: i32,
     pub losses: i32,
     pub password: String,
+    pub email: String,
+}
+
+#[derive(FromRow)]
+pub struct PasswordResetToken {
+    pub id: i32,
+    pub user_id: i32,
+    pub token: String,
+    pub created_at: i64,
+    pub expires_at: i64
 }
 
 #[allow(dead_code)]
@@ -33,7 +43,7 @@ pub struct OverwatchMap {
     pub mode: String,
 }
 
-#[allow(dead_code, Serialize, Default, Debug)]
+#[allow(dead_code)]
 #[derive(sqlx::FromRow, Clone, Serialize, Debug, Default)]
 pub struct OverwatchMatch {
     pub id: i32,

--- a/carnival-web/src/db/queries.rs
+++ b/carnival-web/src/db/queries.rs
@@ -6,6 +6,7 @@ pub mod tables {
         wins INTEGER DEFAULT 0,
         losses INTEGER DEFAULT 0,
         username VARCHAR(250) UNIQUE NOT NULL,
+        email VARCHAR(250) UNIQUE NOT NULL,
         password VARCHAR(250) NOT NULL,
         battletag VARCHAR(17) UNIQUE NOT NULL);";
 
@@ -17,14 +18,14 @@ pub mod tables {
         is_valid BIT NOT NULL,
         invalidation_source VARCHAR(100));";
 
-    pub const CREATE_OW_MAP: &'static str = "CREATE TABLE IF NOT EXISTS
+    pub const CREATE_OW_MAP: &str = "CREATE TABLE IF NOT EXISTS
         overwatch_maps (
             id INTEGER PRIMARY KEY UNIQUE NOT NULL,
             name VARCHAR(64) UNIQUE NOT NULL,
             mode VARCHAR(64) NOT NULL
         );";
 
-    pub const CREATE_OW_MATCH_THRU: &'static str = "CREATE TABLE IF NOT EXISTS
+    pub const CREATE_OW_MATCH_THRU: &str = "CREATE TABLE IF NOT EXISTS
         overwatch_match_players (
             id INTEGER PRIMARY KEY UNIQUE NOT NULL,
             user_id INTEGER NOT NULL,
@@ -32,7 +33,7 @@ pub mod tables {
             team_id INTEGER NOT NULL
         );";
 
-    pub const CREATE_OW_MATCH: &'static str = "CREATE TABLE IF NOT EXISTS
+    pub const CREATE_OW_MATCH: &str = "CREATE TABLE IF NOT EXISTS
         overwatch_match (
             id INTEGER PRIMARY KEY UNIQUE NOT NULL,
             map_id INTEGER NOT NULL,
@@ -40,18 +41,28 @@ pub mod tables {
             status INTEGER DEFAULT 0
         );"; 
     
-    pub const CREATE_QUEUE: &'static str = "CREATE TABLE IF NOT EXISTS
+    pub const CREATE_QUEUE: &str = "CREATE TABLE IF NOT EXISTS
         queues (
             id INTEGER PRIMARY KEY UNIQUE NOT NULL,
             title VARCHAR(100) UNIQUE NOT NULL,
             demographic VARCHAR(100) UNIQUE NOT NULL
         );";
     
-    pub const CREATE_QUEUED_PLAYERS: &'static str = "CREATE TABLE IF NOT EXISTS
+    pub const CREATE_QUEUED_PLAYERS: &str = "CREATE TABLE IF NOT EXISTS
         queued_players (
             id INTEGER PRIMARY KEY UNIQUE NOT NULL,
             queue_id INTEGER NOT NULL,
             user_id INTEGER UNIQUE NOT NULL,
             role VARCHAR(16) NOT NULL
+        );";
+
+    pub const CREATE_PASSWORD_RESET_TOKENS: & str = "CREATE TABLE IF NOT EXISTS
+        password_reset_tokens (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,               -- Primary key implies not null & unique
+            user_id INTEGER UNIQUE NOT NULL,                    -- foreign key to users table 1:1
+            token VARCHAR(36) UNIQUE NOT NULL,                  -- can technically be char cause UUID length is fixed 
+            created_at INTEGER DEFAULT (strftime('%s', 'now')), -- DATETIME exists but something something SQLx compatibility
+            expires_at INTEGER NOT NULL,                        -- maybe we can make it compatible... but I cba
+            FOREIGN KEY(user_id) REFERENCES users(id)           -- foreign key constraint
         );";
 }

--- a/carnival-web/src/db/services/mod.rs
+++ b/carnival-web/src/db/services/mod.rs
@@ -2,3 +2,4 @@ pub mod user;
 pub mod session_token;
 pub mod overwatch_match;
 pub mod queue;
+pub mod password_reset_token;

--- a/carnival-web/src/db/services/password_reset_token.rs
+++ b/carnival-web/src/db/services/password_reset_token.rs
@@ -1,0 +1,70 @@
+use chrono::Utc;
+use sqlx::{sqlite::SqliteQueryResult,  SqlitePool};
+
+use crate::db::models::PasswordResetToken;
+
+pub async fn store_token(
+    user_id: i32,
+    token: &str,
+    expires_at: i64,
+    pool: &SqlitePool,
+) -> Result<SqliteQueryResult, sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO password_reset_tokens (user_id, token, expires_at) VALUES ($1, $2, $3);",
+    )
+    .bind(user_id)
+    .bind(token)
+    .bind(expires_at)
+    .execute(pool)
+    .await
+}
+
+pub async fn validate_token(
+    token: &str,
+    pool: &SqlitePool
+) -> Result<Option<i32>, sqlx::Error> {
+    let record: Option<PasswordResetToken> = sqlx::query_as("SELECT * FROM password_reset_tokens WHERE token = $1")
+        .bind(token)
+        .fetch_optional(pool).await?;
+
+    if let Some(record) = record {
+        if Utc::now().timestamp() < record.expires_at {
+            return Ok(Some(record.user_id));
+        }
+    }
+    Ok(None)
+}
+
+pub async fn delete_token(
+    token: &str,
+    pool: &SqlitePool
+) -> Result<u64, sqlx::Error> {
+    sqlx::query("DELETE FROM password_reset_tokens WHERE token = $1")
+        .bind(token)
+        .execute(pool)
+        .await
+        // Returns number of rows affected... Should always be 1
+        .map(|res| res.rows_affected())
+}
+
+pub async fn update_password(
+    user_id: i32,
+    new_password: &str,
+    pool: &SqlitePool
+) -> Result<(), sqlx::Error> {
+
+    let rows_affected = sqlx::query("UPDATE users SET password = $1 WHERE id = $2")
+        .bind(new_password)
+        .bind(user_id)
+        .execute(pool)
+        .await?
+        .rows_affected();
+
+    // Verify if the password was updated
+    if rows_affected == 0 {
+        // No rows were updated; this might indicate that the `user_id` is invalid
+        return Err(sqlx::Error::RowNotFound);
+    }
+
+    Ok(())
+}

--- a/carnival-web/src/db/services/queue.rs
+++ b/carnival-web/src/db/services/queue.rs
@@ -2,8 +2,6 @@ use sqlx::{SqlitePool, sqlite::SqliteQueryResult};
 
 use crate::db::services::overwatch_match::create_match;
 
-use super::overwatch_match::ResolvedOverwatchMatch;
-
 pub async fn is_queued(
     queue_id: i32,
     username: &str,

--- a/carnival-web/src/db/services/user.rs
+++ b/carnival-web/src/db/services/user.rs
@@ -70,6 +70,10 @@ pub async fn does_username_exist(username: &str, pool: &SqlitePool) -> bool {
     does_exist::<User>("SELECT * FROM users WHERE username = $1", username, pool).await
 }
 
+pub async fn does_email_exist(email: &str, pool: &SqlitePool) -> bool {
+    does_exist::<User>("SELECT * FROM users WHERE email = $1", email, pool).await
+}
+
 pub async fn does_battletag_exist(battletag: &str, pool: &SqlitePool) -> bool {
     does_exist::<User>("SELECT * FROM users WHERE battletag = $1", battletag, pool).await
 }
@@ -92,6 +96,7 @@ pub async fn create_user(
     username: &str,
     password: &str,
     battletag: &str,
+    email: &str,
     role: &str,
     pool: &SqlitePool,
 ) -> Result<SqliteQueryResult, sqlx::Error> {
@@ -101,10 +106,24 @@ pub async fn create_user(
         username,
         hashed_pass,
         battletag,
+        email,
         role
     )
     .execute(pool)
     .await
+}
+
+pub async fn user_by_email(
+    email: &str,
+    pool: &SqlitePool
+) -> Result<User, sqlx::Error> {
+
+    let user = sqlx::query_as::<_, User>("SELECT * FROM users WHERE email = $1")
+        .bind(email)
+        .fetch_one(pool)
+        .await;
+
+    user
 }
 
 #[allow(dead_code)]

--- a/carnival-web/testing/dummy_data.py
+++ b/carnival-web/testing/dummy_data.py
@@ -7,6 +7,7 @@ DUMMY_USERS = [
         "battletag": "DummyTank1#123",
         "password": "123",
         "password_conf": "123",
+        "email": "realuser1@blizzard.com"
     },
     {
         "username": "DummyTank2",
@@ -14,6 +15,7 @@ DUMMY_USERS = [
         "battletag": "DummyTank2#123",
         "password": "123",
         "password_conf": "123",
+        "email": "realuser2@blizzard.com"
     },
     {
         "username": "DummyDPS1",
@@ -21,6 +23,7 @@ DUMMY_USERS = [
         "battletag": "DummyDPS1#123",
         "password": "123",
         "password_conf": "123",
+        "email": "realuser3@blizzard.com"
     },
     {
         "username": "DummyDPS2",
@@ -28,6 +31,7 @@ DUMMY_USERS = [
         "battletag": "DummyDPS2#123",
         "password": "123",
         "password_conf": "123",
+        "email": "realuser4@blizzard.com"
     },
     {
         "username": "DummyDPS3",
@@ -35,6 +39,7 @@ DUMMY_USERS = [
         "battletag": "DummyDPS3#123",
         "password": "123",
         "password_conf": "123",
+        "email": "realuser5@blizzard.com"
     },
     {
         "username": "DummyDPS4",
@@ -42,6 +47,7 @@ DUMMY_USERS = [
         "battletag": "DummyDPS4#123",
         "password": "123",
         "password_conf": "123",
+        "email": "realuser6@blizzard.com"
     },
     {
         "username": "DummySupport1",
@@ -49,6 +55,7 @@ DUMMY_USERS = [
         "battletag": "DummySuppor#123t1",
         "password": "123",
         "password_conf": "123",
+        "email": "realuser7@blizzard.com"
     },
     {
         "username": "DummySupport2",
@@ -56,6 +63,7 @@ DUMMY_USERS = [
         "battletag": "DummySupport2#123",
         "password": "123",
         "password_conf": "123",
+        "email": "realuser8@blizzard.com"
     },
     {
         "username": "DummySupport3",
@@ -63,6 +71,7 @@ DUMMY_USERS = [
         "battletag": "DummySupport3#123",
         "password": "123",
         "password_conf": "123",
+        "email": "realuser9@blizzard.com"
     },
     {
         "username": "DummySupport4",
@@ -70,6 +79,7 @@ DUMMY_USERS = [
         "battletag": "DummySupport4#123",
         "password": "123",
         "password_conf": "123",
+        "email": "realuser10@blizzard.com"
     },
 ]
 

--- a/carnival-web/testing/endpoints/users.py
+++ b/carnival-web/testing/endpoints/users.py
@@ -81,7 +81,8 @@ class RegisterMismatchedPasswords(Test):
             "role": "Tank",
             "password": "123123",
             "password_conf": "1123123",
-            "battletag": "realuser#12333"
+            "battletag": "realuser#12333",
+            "email": "realuserwow@blizzard.com"
         }
         return post_get_response(endpoint="api/register",
                                  json_payload=payload)
@@ -99,6 +100,7 @@ class BattletagExists(Test):
             "battletag": "Fuey500#123",
             "password": "123",
             "password_conf": "123",
+            "email": "realuserxD@blizzard.com"
         }
         post_get_response(endpoint="api/register",
                           json_payload=create_payload)
@@ -108,11 +110,39 @@ class BattletagExists(Test):
             "role": "Tank",
             "password": "123123",
             "password_conf": "123123",
-            "battletag": "Fuey500#123"
+            "battletag": "Fuey500#123",
+            "email": "realuser123@blizzard.com"
         }
         return post_get_response(endpoint="api/register",
                                  json_payload=payload)
 
+class EmailExists(Test):
+    def __init__(self):
+        super().__init__("EmailExists",
+                         Response(400, "Email already exists"))
+
+    def test(self) -> Response:
+        create_payload = {
+            "username": str(uuid.uuid1()).replace("-", "")[0:40],
+            "role": "Tank",
+            "battletag": "Fuey500#123",
+            "password": "123",
+            "password_conf": "123",
+            "email": "realuserxD@blizzard.com"
+        }
+        post_get_response(endpoint="api/register",
+                          json_payload=create_payload)
+
+        payload = {
+            "username": str(uuid.uuid1()).replace("-", "")[0:40],
+            "role": "Tank",
+            "password": "123123",
+            "password_conf": "123123",
+            "battletag": "Fuey501#123",
+            "email": "realuserxD@blizzard.com"
+        }
+        return post_get_response(endpoint="api/register",
+                                 json_payload=payload)
 
 class Login(Test):
     def __init__(self):
@@ -137,6 +167,7 @@ class Register(Test):
             "battletag": str(uuid.uuid1()).replace("-", "")[0:40],
             "password": "123",
             "password_conf": "123",
+            "email": "realuser@blizzard.com"
         }
         return post_get_response(endpoint="api/register", json_payload=payload)
 
@@ -161,6 +192,10 @@ def test_users():
     battletag_exists = BattletagExists()
     battletag_exists_resp = battletag_exists.test()
     battletag_exists.check(battletag_exists_resp)
+
+    email_exists = EmailExists()
+    email_exists_resp = email_exists.test()
+    email_exists.check(email_exists_resp)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Sort of closes #46 

# Changelog

- added ``chrono`` crate for DateTime stuff
- added ``lettre`` crate for email stuff
- added ``password_reset_tokens`` table
- added CRUD for ``password_reset_token`` model
- added ``email`` to user model
- added ``user_by_email`` query
- added 2 endpoints on controller for ``forgot-password`` and ``reset-password``
- NOTE: Check out the [Garde](https://github.com/jprochazk/garde) for validation.
- NOTE: the ``query!()`` macros should be revised or something. This will help with using SQLx CLI. Setup can be as simple as ``cargo sqlx database setup``.